### PR TITLE
perf: improve UI/UX for icon customization panel

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -43,7 +43,7 @@ export default function RootLayout({
 }>): React.JSX.Element {
   return (
     <html lang="en" suppressHydrationWarning>
-      <body className={`${geistSans.variable} ${geistMono.variable} antialiased`}>
+      <body className={`${geistSans.variable} ${geistMono.variable} font-sans antialiased`}>
         <ThemeProvider
           attribute="class"
           defaultTheme="system"

--- a/src/components/customize-panel.tsx
+++ b/src/components/customize-panel.tsx
@@ -34,16 +34,20 @@ function getThemeForegroundColor(): string {
   if (typeof window === 'undefined') return '#000000';
 
   const root = document.documentElement;
-  const style = getComputedStyle(root);
-  const foreground = style.getPropertyValue('--foreground').trim();
+  const isDark = root.classList.contains('dark');
+  return isDark ? '#ffffff' : '#000000';
+}
 
-  // Convert HSL to hex (foreground is in HSL format like "222.2 84% 4.9%")
-  if (foreground) {
-    const isDark = root.classList.contains('dark');
-    return isDark ? '#ffffff' : '#000000';
-  }
+/**
+ * Get the current theme's background color for icon customization.
+ * @returns The background color in hex format.
+ */
+function getThemeBackgroundColor(): string {
+  if (typeof window === 'undefined') return '#ffffff';
 
-  return '#000000';
+  const root = document.documentElement;
+  const isDark = root.classList.contains('dark');
+  return isDark ? '#000000' : '#ffffff';
 }
 
 /**
@@ -71,10 +75,11 @@ export function CustomizePanel({
   const [iconOpacity, setIconOpacity] = useState(100);
   const [backgroundOpacity, setBackgroundOpacity] = useState(100);
 
-  // Update icon color when panel opens to match current theme
+  // Update icon color and background when panel opens to match current theme
   useEffect(() => {
     if (open) {
       setIconColor(getThemeForegroundColor());
+      setBackgroundColor(getThemeBackgroundColor());
     }
   }, [open]);
 
@@ -173,8 +178,12 @@ export function CustomizePanel({
                 type="text"
                 value={iconColor}
                 onChange={(e) => setIconColor(e.target.value)}
-                className="flex-1 rounded border px-3 py-2 text-sm"
+                className="flex-1 rounded border px-3 py-2 text-base"
                 placeholder="#000000"
+                spellCheck={false}
+                autoComplete="off"
+                autoCorrect="off"
+                autoCapitalize="off"
               />
             </div>
           </div>
@@ -210,8 +219,12 @@ export function CustomizePanel({
                 type="text"
                 value={backgroundColor}
                 onChange={(e) => setBackgroundColor(e.target.value)}
-                className="flex-1 rounded border px-3 py-2 text-sm"
+                className="flex-1 rounded border px-3 py-2 text-base"
                 placeholder="#ffffff"
+                spellCheck={false}
+                autoComplete="off"
+                autoCorrect="off"
+                autoCapitalize="off"
               />
             </div>
           </div>

--- a/src/components/icon-grid.tsx
+++ b/src/components/icon-grid.tsx
@@ -70,7 +70,7 @@ export const IconGrid = memo<IconGridProps>(({ icons, onIconSelect, selectedIcon
   };
 
   return (
-    <div className="grid grid-cols-4 gap-2 sm:grid-cols-6 md:grid-cols-8 lg:grid-cols-10 xl:grid-cols-12">
+    <div className="grid grid-cols-4 gap-4 sm:grid-cols-6 md:grid-cols-8 lg:grid-cols-10 xl:grid-cols-12">
       {icons.map((icon) => (
         <IconButton
           key={icon.name}


### PR DESCRIPTION
  - Increase icon grid gap from 0.5rem to 1rem for better spacing
  - Apply Geist Sans font globally by adding font-sans class to body
  - Fix dark mode default colors: now uses white icon on black background
  - Increase color input font size to 16px to prevent iOS auto-zoom
  - Disable spell check and auto-corrections on color code inputs

  These changes improve mobile user experience and fix the issue where
  color hex codes (e.g., #ffffff) were showing red underlines due to
  browser spell checking.

  Files modified:
  - src/components/icon-grid.tsx
  - src/app/layout.tsx
  - src/components/customize-panel.tsx
